### PR TITLE
The munged kernel image also depends on the kernel

### DIFF
--- a/recipes-bcm/kernel-image/bcm2835-kernel-image.bb
+++ b/recipes-bcm/kernel-image/bcm2835-kernel-image.bb
@@ -3,9 +3,9 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=3f40d7994397109285ec7b81fdeb3b58"
 
 COMPATIBLE_MACHINE = "raspberrypi"
-PR = "${MACHINE_KERNEL_PR}.1"
+PR = "${MACHINE_KERNEL_PR}.2"
 
-DEPENDS = "bcm2835-bootfiles bcm2835-mkimage-native"
+DEPENDS = "virtual/kernel bcm2835-bootfiles bcm2835-mkimage-native"
 
 S = "${WORKDIR}"
 


### PR DESCRIPTION
I've added a dependency to bcm2835-kernel-image.bb so that virtual/kernel gets built first if it doesn't already exist.
