### PR TITLE
bcm2835-kernel-image: Fix dependency

### DIFF
--- a/recipes-bcm/kernel-image/bcm2835-kernel-image.bb
+++ b/recipes-bcm/kernel-image/bcm2835-kernel-image.bb
@@ -3,9 +3,9 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=3f40d7994397109285ec7b81fdeb3b58"
 
 COMPATIBLE_MACHINE = "raspberrypi"
-PR = "${MACHINE_KERNEL_PR}.1"
+PR = "${MACHINE_KERNEL_PR}.2"
 
-DEPENDS = "bcm2835-bootfiles bcm2835-mkimage-native"
+DEPENDS = "bcm2835-bootfiles bcm2835-mkimage-native virtual/kernel"
 
 S = "${WORKDIR}"
 


### PR DESCRIPTION
Add dependency on kernel image as it must be built before this
package can be completed.

Signed-off-by: Gary Thomas gary@mlbassoc.com
