### PR TITLE
linux.inc: Remove reference to linux-tools.inc

### DIFF
--- a/recipes-kernel/linux/linux.inc
+++ b/recipes-kernel/linux/linux.inc
@@ -6,9 +6,6 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 
 inherit kernel siteinfo
 
-# Try to build & install perf
-require recipes-kernel/linux/linux-tools.inc
-
 RPSRC = "http://www.rpsys.net/openzaurus/patches/archive"
 
 # Enable OABI compat for people stuck with obsolete userspace


### PR DESCRIPTION
linux-tools.inc was removed. More info:
commit b485f3e0e55ad62079ed0913970ff0620f4808ea
Author: Bruce Ashfield bruce.ashfield@windriver.com
recipes-kernel: remove linux-tools.inc
perf has been moved to a standalone package, making linux-tools.inc
unecessary. It can now be removed and recipes that included it
updated.

Signed-off-by: Andrei Gherzan andrei@gherzan.ro
