### PR TITLE
linux.inc: Activate CONFIG_LEGACY_PTYS needed for bootlogd

### DIFF
--- a/recipes-kernel/linux/linux.inc
+++ b/recipes-kernel/linux/linux.inc
@@ -217,6 +217,12 @@ do_configure_prepend() {
                 echo "CONFIG_CMDLINE=\"${CMDLINE_NFSROOT_USB}\"" >> ${S}/.config
         fi
 		yes '' | oe_runmake oldconfig
+
+		#
+		# Activate CONFIG_LEGACY_PTYS
+		#
+		sed -e '/CONFIG_LEGACY_PTYS/d' -i ${S}/.config
+		echo "CONFIG_LEGACY_PTYS=y" >> ${S}/.config
 }
 
 do_configure_append() {


### PR DESCRIPTION
Activate this to have /dev/ptmx before init script for bootlogd.

[GITHUB #27]

Signed-off-by: Andrei Gherzan andrei@gherzan.ro
