### PR TITLE
raspberrypi.conf: Set udev PREFERRED_VERSION to 164

### DIFF
--- a/conf/machine/raspberrypi.conf
+++ b/conf/machine/raspberrypi.conf
@@ -17,6 +17,8 @@ SERIAL_CONSOLE = "115200 ttyAMA0"
 PREFERRED_PROVIDER_virtual/kernel = "linux-${MACHINE}"
 MACHINE_KERNEL_PR = "r4"
 
+PREFERRED_VERSION_udev = "164"
+
 PREFERRED_PROVIDER_virtual/xserver = "xserver-xorg"
 PREFERRED_PROVIDER_virtual/egl ?= "vc-graphics-hardfp"
 PREFERRED_PROVIDER_virtual/libgles2 ?= "vc-graphics-hardfp"


### PR DESCRIPTION
It seems like rpi kernel doesn't work well with newer udev version so
we set 164 as preferred version for it.

Signed-off-by: Andrei Gherzan andrei@gherzan.ro
