### PR TITLE
Use cmdline.txt to supply kernel command line

### DIFF
--- a/classes/sdcard_image-rpi.bbclass
+++ b/classes/sdcard_image-rpi.bbclass
@@ -92,9 +92,9 @@ IMAGE_CMD_rpi-sdimg () {
 			;;
 	esac
 
-	# To do
-	# Copy here a cmdline.txt file generated taking into consideration the partition type
-	# of the rootfs
+	# TODO
+	# Adjust cmdline.txt to reflect the rootfs partition type
+	mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/bcm2835-bootfiles/cmdline.txt ::
 	mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/bcm2835-bootfiles/bootcode.bin ::
 	mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/bcm2835-bootfiles/loader.bin ::
 	mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}-${MACHINE}.bin ::kernel.img

--- a/recipes-kernel/linux/linux-raspberrypi_3.2.27.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_3.2.27.bb
@@ -4,7 +4,7 @@ require linux.inc
 
 DESCRIPTION = "Linux kernel for the RaspberryPi board"
 
-PR = "r0"
+PR = "r1"
 
 # Bump MACHINE_KERNEL_PR in the machine config if you update the kernel.
 # This is on the rpi-patches branch
@@ -35,4 +35,9 @@ do_configure_prepend() {
 
 do_install_prepend() {
 	install -d ${D}/lib/firmware
+}
+
+do_deploy_append() {
+	install -d ${DEPLOY_DIR_IMAGE}/bcm2835-bootfiles
+        echo "${CMDLINE}" > ${DEPLOY_DIR_IMAGE}/bcm2835-bootfiles/cmdline.txt
 }


### PR DESCRIPTION
The build-time kernel command line (as defined by the CONFIG_CMDLINE config
parameter) is not respected by the RPI bootloader, and instead any custom
command line must be suplied via the cmdline.txt file in the boot partition.

This patch modifies the linux-raspberrypi recipe to generate a cmdline.txt
file that corresponds to the build-time configured command line, and it
also modifies the sdcard_image-rpi.bbclass to include this file in the
generated SD card images.

[GITHUB #62]
