### PR TITLE
README: fix typo in DISABLE_OVERSCAN

### DIFF
--- a/README
+++ b/README
@@ -121,7 +121,7 @@ KEY_DECODE_WVC1 = "0x12345678,0xabcdabcd,0x87654321"
 By default the GPU adds a black border around the video output to compensate for
 TVs which cut off part of the image. To disable this set this variable in
 local.conf:
-DISALE_OVERSCAN = "0"
+DISABLE_OVERSCAN = "0"
 
 2.E. Optional - Set overclocking options:
 =========================================


### PR DESCRIPTION
Found and fixed a typo in top-level README.
